### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.18
 require (
 	github.com/andybalholm/brotli v1.0.4
 	github.com/jackc/puddle v1.2.1
-	github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6
+	github.com/tetratelabs/wazero v1.0.0-beta.1
 )

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6 h1:TEaSLWw5JT+Nk6WBIu2fl6uNWhOIu9U6zow+ugbD+bc=
-github.com/tetratelabs/wazero v0.0.0-20220812081006-d7d18a5519e6/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=

--- a/mjml.go
+++ b/mjml.go
@@ -29,6 +29,8 @@ var (
 )
 
 func init() {
+	ctx := context.Background()
+
 	results = &sync.Map{}
 
 	br := brotli.NewReader(bytes.NewReader(wasm))
@@ -38,19 +40,19 @@ func init() {
 		panic(fmt.Sprintf("Error decompressing wasm file: %s", err))
 	}
 
-	runtime = wazero.NewRuntime() // TODO: this should be closed
+	runtime = wazero.NewRuntime(ctx) // TODO: this should be closed
 
-	if _, err := wasi_snapshot_preview1.Instantiate(nil, runtime); err != nil {
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, runtime); err != nil {
 		panic(fmt.Sprintf("Error instantiating wasi snapshot preview 1: %s", err))
 	}
 
-	err = registerHostFunctions(nil, runtime)
+	err = registerHostFunctions(ctx, runtime)
 
 	if err != nil {
 		panic(fmt.Sprintf("Error registering host functions: %s", err))
 	}
 
-	compiled, err = runtime.CompileModule(nil, decompressed, wazero.NewCompileConfig())
+	compiled, err = runtime.CompileModule(ctx, decompressed, wazero.NewCompileConfig())
 
 	if err != nil {
 		panic(fmt.Sprintf("Error compiling wasm module: %s", err))


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io): 1.0.0-beta.1

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.
