### PR TITLE
deps: updates wazero to 1.0.0-pre.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.18
 require (
 	github.com/andybalholm/brotli v1.0.4
 	github.com/jackc/puddle v1.2.1
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.5
 )

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.5 h1:ChZsQewsazFwF+NT6qAKPwnqqiOlf2MN0aah1dlD8Bk=
+github.com/tetratelabs/wazero v1.0.0-pre.5/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=

--- a/mjml.go
+++ b/mjml.go
@@ -175,7 +175,7 @@ func ToHTML(ctx context.Context, mjml string, toHTMLOptions ...ToHTMLOption) (st
 
 	defer deallocate.Call(ctx, inputPtr)
 
-	if !memory.Write(ctx, uint32(inputPtr), []byte(jsonInput)) {
+	if !memory.Write(uint32(inputPtr), []byte(jsonInput)) {
 		return "", fmt.Errorf("error writing input to memory: %w", err)
 	}
 
@@ -294,7 +294,7 @@ func registerHostFunctions(ctx context.Context, r wazero.Runtime) error {
 // api.GoModuleFunc because it isn't called frequently.
 func returnResult(ctx context.Context, m api.Module, ptr uint32, len uint32, ident uint32) {
 	if ch, ok := results.Load(int32(ident)); ok {
-		result, ok := m.Memory().Read(ctx, ptr, len)
+		result, ok := m.Memory().Read(ptr, len)
 
 		resultCh, isResultCh := ch.(chan []byte)
 


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.5](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.5).